### PR TITLE
update broken link to ACI provider point to the repo, not just readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Virtual kubelet integration allows you to take advantage of this from within
 
 Azure Batch allows for [low priority nodes](https://docs.microsoft.com/en-us/azure/batch/batch-low-pri-vms) which can also help to reduce cost for non-time sensitive workloads.
 
-__The [ACI provider](../azure/README.md) is the best option unless you're looking to utilise some specific features of Azure Batch__.
+__The [ACI provider](https://github.com/virtual-kubelet/azure-aci) is the best option unless you're looking to utilise some specific features of Azure Batch__.
 
 ## Status: Experimental
 


### PR DESCRIPTION
The link as-is is 404'ing.  
This update directs the user to the correct repo, I believe.  I also changed the link to point to the full repo instead of just the `README.md`, since that feels more natural when looking at a different project.